### PR TITLE
Re-add dynamic-import plugin on test envs

### DIFF
--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -34,7 +34,9 @@ Object {
       ],
     },
     "test": Object {
-      "plugins": Array [],
+      "plugins": Array [
+        "dynamic-import-node",
+      ],
     },
   },
   "plugins": Array [
@@ -133,7 +135,9 @@ Object {
       ],
     },
     "test": Object {
-      "plugins": Array [],
+      "plugins": Array [
+        "dynamic-import-node",
+      ],
     },
   },
   "plugins": Array [

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ const configureEnv = (env, target) => ({
     ]),
   },
   test: {
-    plugins: compact([target === 'node' && 'dynamic-import-node']),
+    plugins: ['dynamic-import-node'],
   },
   production: {
     plugins: ['transform-react-remove-prop-types', 'graphql-tag'],


### PR DESCRIPTION
After #13 was merged, test envs in browser mode didn't
include the `dynamic-import` plugin, which is a bug.

This commit fixes that.