### PR TITLE
Move invariant from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "eslint": "^4.13.1",
     "graphql": "^14.0.2",
     "graphql-tag": "^2.9.2",
-    "invariant": "^2.2.4",
     "jest": "^21.2.1"
   },
   "dependencies": {
@@ -41,7 +40,8 @@
     "babel-plugin-emotion": "^10.0.0",
     "babel-plugin-graphql-tag": "^1.6.0",
     "babel-plugin-require-context-hook": "^1.0.0",
-    "babel-plugin-transform-react-remove-prop-types": "^0.4.10"
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.10",
+    "invariant": "^2.2.4"
   },
   "jest": {
     "testMatch": [


### PR DESCRIPTION
Technically `invariant` is used at runtime so it should sit in `dependencies`. Note that Yarn PnP complains about it not being in `dependencies`.