### PR TITLE
Add @babel/preset-typescript to allow TypeScript files

### DIFF
--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -39,6 +39,39 @@ Object {
       ],
     },
   },
+  "overrides": Array [
+    Object {
+      "presets": Array [
+        Array [
+          "@babel/preset-env",
+          Object {
+            "modules": false,
+            "targets": Object {
+              "browsers": Array [
+                "last 4 Chrome major versions",
+                "last 4 Firefox major versions",
+                "last 2 Safari major versions",
+                "last 3 Edge major versions",
+                "last 4 ChromeAndroid major versions",
+                "last 2 iOS major versions",
+              ],
+            },
+          },
+        ],
+        "@babel/preset-react",
+        Array [
+          "@babel/typescript",
+          Object {
+            "allExtensions": true,
+            "isTSX": true,
+          },
+        ],
+      ],
+      "test": Array [
+        "*.ts",
+      ],
+    },
+  ],
   "plugins": Array [
     "@babel/plugin-syntax-dynamic-import",
     "@babel/plugin-proposal-object-rest-spread",
@@ -86,6 +119,32 @@ Object {
       ],
     },
   },
+  "overrides": Array [
+    Object {
+      "presets": Array [
+        Array [
+          "@babel/preset-env",
+          Object {
+            "modules": "commonjs",
+            "targets": Object {
+              "node": "current",
+            },
+          },
+        ],
+        "@babel/preset-react",
+        Array [
+          "@babel/typescript",
+          Object {
+            "allExtensions": true,
+            "isTSX": true,
+          },
+        ],
+      ],
+      "test": Array [
+        "*.ts",
+      ],
+    },
+  ],
   "plugins": Array [
     "@babel/plugin-syntax-dynamic-import",
     "@babel/plugin-proposal-object-rest-spread",
@@ -108,6 +167,15 @@ Object {
 `;
 
 exports[`babel-preset-zapier strips flow annotations 1`] = `"function greet(name) {}"`;
+
+exports[`babel-preset-zapier transpiles TS 1`] = `"const x = 7;"`;
+
+exports[`babel-preset-zapier transpiles TSX 1`] = `
+"import * as React from 'react';
+export function Thing(props) {
+  return React.createElement(\\"h1\\", null, props.foo);
+}"
+`;
 
 exports[`babel-preset-zapier when on production env strips proptypes when in prod env 1`] = `"const Baz = props => React.createElement(\\"div\\", props);"`;
 
@@ -140,6 +208,39 @@ Object {
       ],
     },
   },
+  "overrides": Array [
+    Object {
+      "presets": Array [
+        Array [
+          "@babel/preset-env",
+          Object {
+            "modules": "commonjs",
+            "targets": Object {
+              "browsers": Array [
+                "last 4 Chrome major versions",
+                "last 4 Firefox major versions",
+                "last 2 Safari major versions",
+                "last 3 Edge major versions",
+                "last 4 ChromeAndroid major versions",
+                "last 2 iOS major versions",
+              ],
+            },
+          },
+        ],
+        "@babel/preset-react",
+        Array [
+          "@babel/typescript",
+          Object {
+            "allExtensions": true,
+            "isTSX": true,
+          },
+        ],
+      ],
+      "test": Array [
+        "*.ts",
+      ],
+    },
+  ],
   "plugins": Array [
     "@babel/plugin-syntax-dynamic-import",
     "@babel/plugin-proposal-object-rest-spread",

--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -177,6 +177,31 @@ export function Thing(props) {
 }"
 `;
 
+exports[`babel-preset-zapier transpiles TSX with emotion jsx pragma 1`] = `
+"/** @jsx jsx */
+import { css, jsx } from '@emotion/core';
+const styles = process.env.NODE_ENV === \\"production\\" ? {
+  name: \\"tbsp7d-foo--styles\\",
+  styles: \\"display:block;label:foo--styles;\\"
+} : {
+  name: \\"tbsp7d-foo--styles\\",
+  styles: \\"display:block;label:foo--styles;\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZvby50c3giXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBR3FCIiwiZmlsZSI6ImZvby50c3giLCJzb3VyY2VzQ29udGVudCI6WyJcbiAgICAgIC8qKiBAanN4IGpzeCAqL1xuICAgICAgaW1wb3J0IHsgY3NzLCBqc3ggfSBmcm9tICdAZW1vdGlvbi9jb3JlJztcbiAgICAgIGNvbnN0IHN0eWxlcyA9IGNzcyh7XG4gICAgICAgIGRpc3BsYXk6ICdibG9jaycsXG4gICAgICB9KTtcbiAgICAgIGludGVyZmFjZSBJUHJvcHMge1xuICAgICAgICBmb286IHN0cmluZztcbiAgICAgIH1cblxuICAgICAgZXhwb3J0IGZ1bmN0aW9uIFRoaW5nKHByb3BzOiBJUHJvcHMpIHtcbiAgICAgICAgcmV0dXJuIDxoMSBjc3M9e3N0eWxlc30+e3Byb3BzLmZvb308L2gxPjtcbiAgICAgIH1cbiAgICAiXX0= */\\"
+};
+export function Thing(props) {
+  return jsx(\\"h1\\", {
+    css: styles
+  }, props.foo);
+}"
+`;
+
+exports[`babel-preset-zapier transpiles TSX with isolateComponent pragma 1`] = `
+"// @jsx isolateComponent
+export function Thing(props) {
+  return isolateComponent(\\"h1\\", null, props.foo);
+}"
+`;
+
 exports[`babel-preset-zapier when on production env strips proptypes when in prod env 1`] = `"const Baz = props => React.createElement(\\"div\\", props);"`;
 
 exports[`babel-preset-zapier when on test env compiles to commonjs modules in test environment 1`] = `"import Foo from 'foo';"`;

--- a/index.js
+++ b/index.js
@@ -37,6 +37,25 @@ const configurePresets = (env, target) =>
     '@babel/preset-flow',
   ]);
 
+const configureOverrides = (env, target) =>
+  compact([
+    {
+      test: ['*.ts'],
+      presets: [
+        ...configurePresets(env, target).filter(
+          preset => preset !== '@babel/preset-flow'
+        ),
+        [
+          '@babel/typescript',
+          {
+            allExtensions: true,
+            isTSX: true,
+          },
+        ],
+      ],
+    },
+  ]);
+
 const configurePlugins = (env, target) =>
   compact([
     '@babel/plugin-syntax-dynamic-import',
@@ -80,6 +99,7 @@ module.exports = declare((api, options) => {
 
   return {
     presets: configurePresets(env, target),
+    overrides: configureOverrides(env, target),
     plugins: configurePlugins(env, target),
     env: configureEnv(env, target),
   };

--- a/index.test.js
+++ b/index.test.js
@@ -92,6 +92,41 @@ describe('babel-preset-zapier', () => {
     expect(transform(code, 'foo.tsx')).toMatchSnapshot();
   });
 
+  fit('transpiles TSX with isolateComponent pragma', () => {
+    const code = `
+      // @jsx isolateComponent
+      
+      interface IProps {
+        foo: string;
+      }
+
+      export function Thing(props: IProps) {
+        return <h1>{props.foo}</h1>;
+      }
+    `;
+
+    expect(transform(code, 'foo.tsx')).toMatchSnapshot();
+  });
+
+  fit('transpiles TSX with emotion jsx pragma', () => {
+    const code = `
+      /** @jsx jsx */
+      import { css, jsx } from '@emotion/core';
+      const styles = css({
+        display: 'block',
+      });
+      interface IProps {
+        foo: string;
+      }
+
+      export function Thing(props: IProps) {
+        return <h1 css={styles}>{props.foo}</h1>;
+      }
+    `;
+
+    expect(transform(code, 'foo.tsx')).toMatchSnapshot();
+  });
+
   describe('when on production env', () => {
     beforeEach(() => {
       process.env.BABEL_ENV = 'production';

--- a/index.test.js
+++ b/index.test.js
@@ -92,7 +92,7 @@ describe('babel-preset-zapier', () => {
     expect(transform(code, 'foo.tsx')).toMatchSnapshot();
   });
 
-  fit('transpiles TSX with isolateComponent pragma', () => {
+  it('transpiles TSX with isolateComponent pragma', () => {
     const code = `
       // @jsx isolateComponent
       
@@ -108,7 +108,7 @@ describe('babel-preset-zapier', () => {
     expect(transform(code, 'foo.tsx')).toMatchSnapshot();
   });
 
-  fit('transpiles TSX with emotion jsx pragma', () => {
+  it('transpiles TSX with emotion jsx pragma', () => {
     const code = `
       /** @jsx jsx */
       import { css, jsx } from '@emotion/core';

--- a/index.test.js
+++ b/index.test.js
@@ -1,9 +1,10 @@
 const babel = require('@babel/core');
 
-const transform = code => {
+const transform = (code, filename = 'foo.js') => {
   return babel.transformSync(code, {
     configFile: require.resolve('./index'),
     babelrc: false, // don't use .babelrc
+    filename,
   }).code;
 };
 
@@ -64,6 +65,31 @@ describe('babel-preset-zapier', () => {
     `;
 
     expect(transform(code)).toMatchSnapshot();
+  });
+
+  it('transpiles TS', () => {
+    const code = `
+      const x: number = 7;
+      type Foo = string | any;
+    `;
+
+    expect(transform(code, 'foo.ts')).toMatchSnapshot();
+  });
+
+  it('transpiles TSX', () => {
+    const code = `
+      import * as React from 'react';
+      
+      interface IProps {
+        foo: string;
+      }
+
+      export function Thing(props: IProps) {
+        return <h1>{props.foo}</h1>;
+      }
+    `;
+
+    expect(transform(code, 'foo.tsx')).toMatchSnapshot();
   });
 
   describe('when on production env', () => {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.1.0",
+    "@babel/preset-typescript": "7.3.3",
     "@zapier/eslint-plugin-zapier": "^5.1.1",
     "eslint": "^4.13.1",
     "graphql": "^14.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,13 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
+"@babel/code-frame@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
+  integrity sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==
+  dependencies:
+    "@babel/highlight" "^7.0.0"
+
 "@babel/core@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.1.0.tgz#08958f1371179f62df6966d8a614003d11faeb04"
@@ -58,6 +65,17 @@
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
+"@babel/generator@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.5.5.tgz#873a7f936a3c89491b43536d12245b626664e3cf"
+  integrity sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==
+  dependencies:
+    "@babel/types" "^7.5.5"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+    trim-right "^1.0.1"
+
 "@babel/helper-annotate-as-pure@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0.tgz#323d39dd0b50e10c7c06ca7d7638e6864d8c5c32"
@@ -89,6 +107,18 @@
     "@babel/helper-hoist-variables" "^7.0.0"
     "@babel/traverse" "^7.1.0"
     "@babel/types" "^7.0.0"
+
+"@babel/helper-create-class-features-plugin@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.5.5.tgz#401f302c8ddbc0edd36f7c6b2887d8fa1122e5a4"
+  integrity sha512-ZsxkyYiRA7Bg+ZTRpPvB6AbOFKTFFK4LrvTet8lInm0V468MWCaSYJE+I7v2z2r8KNLtYiV+K5kTCnR7dvyZjg==
+  dependencies:
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-member-expression-to-functions" "^7.5.5"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/helper-replace-supers" "^7.5.5"
+    "@babel/helper-split-export-declaration" "^7.4.4"
 
 "@babel/helper-define-map@^7.1.0":
   version "7.1.0"
@@ -153,6 +183,13 @@
   dependencies:
     "@babel/types" "^7.0.0"
 
+"@babel/helper-member-expression-to-functions@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz#1fb5b8ec4453a93c439ee9fe3aeea4a84b76b590"
+  integrity sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==
+  dependencies:
+    "@babel/types" "^7.5.5"
+
 "@babel/helper-module-imports@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz#96081b7111e486da4d2cd971ad1a4fe216cc2e3d"
@@ -212,6 +249,16 @@
     "@babel/traverse" "^7.1.0"
     "@babel/types" "^7.0.0"
 
+"@babel/helper-replace-supers@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz#f84ce43df031222d2bad068d2626cb5799c34bc2"
+  integrity sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.5.5"
+    "@babel/helper-optimise-call-expression" "^7.0.0"
+    "@babel/traverse" "^7.5.5"
+    "@babel/types" "^7.5.5"
+
 "@babel/helper-simple-access@^7.1.0":
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz#65eeb954c8c245beaa4e859da6188f39d71e585c"
@@ -233,6 +280,13 @@
   integrity sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==
   dependencies:
     "@babel/types" "^7.0.0"
+
+"@babel/helper-split-export-declaration@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz#ff94894a340be78f53f06af038b205c49d993677"
+  integrity sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==
+  dependencies:
+    "@babel/types" "^7.4.4"
 
 "@babel/helper-wrap-function@^7.1.0":
   version "7.1.0"
@@ -275,6 +329,11 @@
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.1.0.tgz#a7cd42cb3c12aec52e24375189a47b39759b783e"
   integrity sha512-SmjnXCuPAlai75AFtzv+KCBcJ3sDDWbIn+WytKw1k+wAtEy6phqI2RqKh/zAnw53i1NR8su3Ep/UoqaKcimuLg==
+
+"@babel/parser@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.5.5.tgz#02f077ac8817d3df4a832ef59de67565e71cca4b"
+  integrity sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==
 
 "@babel/plugin-proposal-async-generator-functions@^7.1.0":
   version "7.1.0"
@@ -383,6 +442,13 @@
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.0.0.tgz#886f72008b3a8b185977f7cb70713b45e51ee475"
   integrity sha512-Wc+HVvwjcq5qBg1w5RG9o9RVzmCaAg/Vp0erHCKpAYV8La6I94o4GQAmFYNmkzoMO6gzoOSulpKeSSz6mPEoZw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-typescript@^7.2.0":
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.3.3.tgz#a7cc3f66119a9f7ebe2de5383cce193473d65991"
+  integrity sha512-dGwbSMA1YhVS8+31CnPR7LB4pcbrzcV99wQzby4uAfrkZPYZlQ7ImwdpzLqi6Z6IL02b8IAL379CaMwo0x5Lag==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
@@ -632,6 +698,15 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-transform-typescript@^7.3.2":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.5.5.tgz#6d862766f09b2da1cb1f7d505fe2aedab6b7d4b8"
+  integrity sha512-pehKf4m640myZu5B2ZviLaiBlxMCjSZ1qTEO459AXKX5GnPueyulJeCqZFs1nz/Ya2dDzXQ1NxZ/kKNWyD4h6w==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.5.5"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-typescript" "^7.2.0"
+
 "@babel/plugin-transform-unicode-regex@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0.tgz#c6780e5b1863a76fe792d90eded9fcd5b51d68fc"
@@ -707,6 +782,14 @@
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
 
+"@babel/preset-typescript@7.3.3":
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.3.3.tgz#88669911053fa16b2b276ea2ede2ca603b3f307a"
+  integrity sha512-mzMVuIP4lqtn4du2ynEfdO0+RYcslwrZiJHXu4MGaC1ctJiW2fyaeDrtjJGs7R/KebZ1sgowcIoWf4uRpEfKEg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-transform-typescript" "^7.3.2"
+
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "http://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"
@@ -757,6 +840,21 @@
     globals "^11.1.0"
     lodash "^4.17.10"
 
+"@babel/traverse@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.5.5.tgz#f664f8f368ed32988cd648da9f72d5ca70f165bb"
+  integrity sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.5.5"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    "@babel/parser" "^7.5.5"
+    "@babel/types" "^7.5.5"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/types@7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "http://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz#6b1b164591f77dec0a0342aca995f2d046b3a757"
@@ -773,6 +871,15 @@
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.10"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.4.4", "@babel/types@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.5.5.tgz#97b9f728e182785909aa4ab56264f090a028d18a"
+  integrity sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
 "@emotion/hash@0.7.1":
@@ -1693,6 +1800,13 @@ debug@^3.1.0:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.5.tgz#c2418fbfd7a29f4d4f70ff4cea604d4b64c46407"
   integrity sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==
+  dependencies:
+    ms "^2.1.1"
+
+debug@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -3401,6 +3515,11 @@ lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+
+lodash@^4.17.13:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 loose-envify@^1.0.0, loose-envify@^1.3.1:
   version "1.4.0"


### PR DESCRIPTION
In @zapier/zapier we use `babel-preset-zapier` for our babel configuration.

#wg-typescript decided to use babel to transpile TS instead of converting our repo to using `tsc` as the compiler. Since babel can transpile TypeScript, this is a very simple change here. Once @zapier/zapier adopts this change, there will only need to be minor changes to the webpack configuration to have webpack acknowledge `*.ts(x)` files, and after that the groundwork is complete.