### PR TITLE
Update tests to properly handle react-hot-loader

### DIFF
--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -77,6 +77,7 @@ Object {
     "@babel/plugin-proposal-object-rest-spread",
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-transform-classes",
+    "react-hot-loader/babel",
   ],
   "presets": Array [
     Array [
@@ -149,6 +150,7 @@ Object {
     "@babel/plugin-syntax-dynamic-import",
     "@babel/plugin-proposal-object-rest-spread",
     "@babel/plugin-proposal-class-properties",
+    "react-hot-loader/babel",
   ],
   "presets": Array [
     Array [

--- a/index.test.js
+++ b/index.test.js
@@ -8,6 +8,12 @@ const transform = (code, filename = 'foo.js') => {
   }).code;
 };
 
+// For testing purposes, we are just using the production version
+// of react-hot-loader/babel so we don't get extra output in our files
+jest.mock('react-hot-loader/babel', () =>
+  require('react-hot-loader/dist/babel.production.min.js')
+);
+
 const tetstConfig = () =>
   require('./index')({
     assertVersion: () => true,


### PR DESCRIPTION
In babel-preset-zapier/20 I introduced a change that broke the tests.

This PR mocks out `react-hot-loader/babel` to always default to the production build so that our snapshots do not add lots of additional noise.