### PR TITLE
Load `react-hot-loader` in all environments

### DIFF
--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -274,6 +274,7 @@ Object {
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-transform-classes",
     "babel-plugin-require-context-hook",
+    "react-hot-loader/babel",
   ],
   "presets": Array [
     Array [

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ const configurePlugins = (env, target) =>
     // Once the fix for this lands on Edge, we can get rid of this (but make sure to test in older versions of Edge first!).
     target === 'browser' && '@babel/plugin-transform-classes',
     env === 'test' && 'babel-plugin-require-context-hook',
-    env === 'development' && 'react-hot-loader/babel',
+    'react-hot-loader/babel',
   ]);
 
 const configureEnv = (env, target) => ({

--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ const configurePlugins = (env, target) =>
     // Once the fix for this lands on Edge, we can get rid of this (but make sure to test in older versions of Edge first!).
     target === 'browser' && '@babel/plugin-transform-classes',
     env === 'test' && 'babel-plugin-require-context-hook',
+    // See: https://github.com/zapier/zapier/pull/31809#discussion_r332164627
     'react-hot-loader/babel',
   ]);
 


### PR DESCRIPTION
@vitorbal pointed out that if we only load `react-hot-loader/babel` when `env === 'development'`, it won't properly work in production.

https://github.com/zapier/zapier/pull/31809#discussion_r333431508

This tool properly strips out `hot` so that it effectively becomes a noop when not in development, so we can default to this behavior.