### PR TITLE
Use a regexp to match .tsx files

### DIFF
--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -67,9 +67,7 @@ Object {
           },
         ],
       ],
-      "test": Array [
-        "*.ts",
-      ],
+      "test": /\\\\\\.tsx\\?\\$/,
     },
   ],
   "plugins": Array [
@@ -141,9 +139,7 @@ Object {
           },
         ],
       ],
-      "test": Array [
-        "*.ts",
-      ],
+      "test": /\\\\\\.tsx\\?\\$/,
     },
   ],
   "plugins": Array [
@@ -188,7 +184,7 @@ const styles = process.env.NODE_ENV === \\"production\\" ? {
 } : {
   name: \\"tbsp7d-foo--styles\\",
   styles: \\"display:block;label:foo--styles;\\",
-  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZvby50c3giXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBR3FCIiwiZmlsZSI6ImZvby50c3giLCJzb3VyY2VzQ29udGVudCI6WyJcbiAgICAgIC8qKiBAanN4IGpzeCAqL1xuICAgICAgaW1wb3J0IHsgY3NzLCBqc3ggfSBmcm9tICdAZW1vdGlvbi9jb3JlJztcbiAgICAgIGNvbnN0IHN0eWxlcyA9IGNzcyh7XG4gICAgICAgIGRpc3BsYXk6ICdibG9jaycsXG4gICAgICB9KTtcbiAgICAgIGludGVyZmFjZSBJUHJvcHMge1xuICAgICAgICBmb286IHN0cmluZztcbiAgICAgIH1cblxuICAgICAgZXhwb3J0IGZ1bmN0aW9uIFRoaW5nKHByb3BzOiBJUHJvcHMpIHtcbiAgICAgICAgcmV0dXJuIDxoMSBjc3M9e3N0eWxlc30+e3Byb3BzLmZvb308L2gxPjtcbiAgICAgIH1cbiAgICAiXX0= */\\"
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZvby50c3giXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBR3FCIiwiZmlsZSI6ImZvby50c3giLCJzb3VyY2VzQ29udGVudCI6WyJcbiAgICAgIC8qKiBAanN4IGpzeCAqL1xuICAgICAgaW1wb3J0IHsgY3NzLCBqc3ggfSBmcm9tICdAZW1vdGlvbi9jb3JlJztcbiAgICAgIGNvbnN0IHN0eWxlcyA9IGNzcyh7XG4gICAgICAgIGRpc3BsYXk6ICdibG9jaycsXG4gICAgICB9KTtcblxuICAgICAgaW50ZXJmYWNlIElQcm9wcyB7XG4gICAgICAgIGZvbzogbnVtYmVyO1xuICAgICAgfVxuXG4gICAgICBleHBvcnQgZnVuY3Rpb24gVGhpbmcocHJvcHM6IElQcm9wcykge1xuICAgICAgICByZXR1cm4gPGgxIGNzcz17c3R5bGVzfT57cHJvcHMuZm9vIGFzIHN0cmluZ308L2gxPjtcbiAgICAgIH1cbiAgICAiXX0= */\\"
 };
 export function Thing(props) {
   return jsx(\\"h1\\", {
@@ -263,9 +259,7 @@ Object {
           },
         ],
       ],
-      "test": Array [
-        "*.ts",
-      ],
+      "test": /\\\\\\.tsx\\?\\$/,
     },
   ],
   "plugins": Array [

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ const configurePresets = (env, target) =>
 const configureOverrides = (env, target) =>
   compact([
     {
-      test: ['*.ts'],
+      test: /\.tsx?$/,
       presets: [
         ...configurePresets(env, target).filter(
           preset => preset !== '@babel/preset-flow'

--- a/index.test.js
+++ b/index.test.js
@@ -87,11 +87,11 @@ describe('babel-preset-zapier', () => {
       import * as React from 'react';
       
       interface IProps {
-        foo: string;
+        foo: number;
       }
 
       export function Thing(props: IProps) {
-        return <h1>{props.foo}</h1>;
+        return <h1>{props.foo as string}</h1>;
       }
     `;
 
@@ -103,11 +103,11 @@ describe('babel-preset-zapier', () => {
       // @jsx isolateComponent
       
       interface IProps {
-        foo: string;
+        foo: number;
       }
 
       export function Thing(props: IProps) {
-        return <h1>{props.foo}</h1>;
+        return <h1>{props.foo as string}</h1>;
       }
     `;
 
@@ -121,12 +121,13 @@ describe('babel-preset-zapier', () => {
       const styles = css({
         display: 'block',
       });
+
       interface IProps {
-        foo: string;
+        foo: number;
       }
 
       export function Thing(props: IProps) {
-        return <h1 css={styles}>{props.foo}</h1>;
+        return <h1 css={styles}>{props.foo as string}</h1>;
       }
     `;
 


### PR DESCRIPTION
`.tsx` files were not matched by the override dedicated to Typescript.

Tests on `.tsx` files were false-positives because the tested source code syntax is compatible with Flow. Adding a Typescript construct (ie. `as`) in the tested source code made the tests of `foo.tsx` fail.