### PR TITLE
Remove autoLabel for `development`

### DIFF
--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -12,24 +12,6 @@ Baz.propTypes = {
 };"
 `;
 
-exports[`babel-preset-zapier emotion testing emotion 1`] = `
-"/** @jsx jsx */
-import { css, jsx } from '@emotion/core';
-const styles = process.env.NODE_ENV === \\"production\\" ? {
-  name: \\"tbsp7d-foo--styles\\",
-  styles: \\"display:block;label:foo--styles;\\"
-} : {
-  name: \\"tbsp7d-foo--styles\\",
-  styles: \\"display:block;label:foo--styles;\\",
-  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZvby50c3giXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBR3FCIiwiZmlsZSI6ImZvby50c3giLCJzb3VyY2VzQ29udGVudCI6WyJcbiAgICAgIC8qKiBAanN4IGpzeCAqL1xuICAgICAgaW1wb3J0IHsgY3NzLCBqc3ggfSBmcm9tICdAZW1vdGlvbi9jb3JlJztcbiAgICAgIGNvbnN0IHN0eWxlcyA9IGNzcyh7XG4gICAgICAgIGRpc3BsYXk6ICdibG9jaycsXG4gICAgICB9KTtcblxuICAgICAgaW50ZXJmYWNlIElQcm9wcyB7XG4gICAgICAgIGZvbzogbnVtYmVyO1xuICAgICAgfVxuXG4gICAgICBleHBvcnQgZnVuY3Rpb24gVGhpbmcocHJvcHM6IElQcm9wcykge1xuICAgICAgICByZXR1cm4gPGgxIGNzcz17c3R5bGVzfT57cHJvcHMuZm9vIGFzIHN0cmluZ308L2gxPjtcbiAgICAgIH1cbiAgICAiXX0= */\\"
-};
-export function Thing(props) {
-  return jsx(\\"h1\\", {
-    css: styles
-  }, props.foo);
-}"
-`;
-
 exports[`babel-preset-zapier given a target option produces the appropriate configuration for browser 1`] = `
 Object {
   "env": Object {

--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -12,6 +12,24 @@ Baz.propTypes = {
 };"
 `;
 
+exports[`babel-preset-zapier emotion testing emotion 1`] = `
+"/** @jsx jsx */
+import { css, jsx } from '@emotion/core';
+const styles = process.env.NODE_ENV === \\"production\\" ? {
+  name: \\"tbsp7d-foo--styles\\",
+  styles: \\"display:block;label:foo--styles;\\"
+} : {
+  name: \\"tbsp7d-foo--styles\\",
+  styles: \\"display:block;label:foo--styles;\\",
+  map: \\"/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImZvby50c3giXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBR3FCIiwiZmlsZSI6ImZvby50c3giLCJzb3VyY2VzQ29udGVudCI6WyJcbiAgICAgIC8qKiBAanN4IGpzeCAqL1xuICAgICAgaW1wb3J0IHsgY3NzLCBqc3ggfSBmcm9tICdAZW1vdGlvbi9jb3JlJztcbiAgICAgIGNvbnN0IHN0eWxlcyA9IGNzcyh7XG4gICAgICAgIGRpc3BsYXk6ICdibG9jaycsXG4gICAgICB9KTtcblxuICAgICAgaW50ZXJmYWNlIElQcm9wcyB7XG4gICAgICAgIGZvbzogbnVtYmVyO1xuICAgICAgfVxuXG4gICAgICBleHBvcnQgZnVuY3Rpb24gVGhpbmcocHJvcHM6IElQcm9wcykge1xuICAgICAgICByZXR1cm4gPGgxIGNzcz17c3R5bGVzfT57cHJvcHMuZm9vIGFzIHN0cmluZ308L2gxPjtcbiAgICAgIH1cbiAgICAiXX0= */\\"
+};
+export function Thing(props) {
+  return jsx(\\"h1\\", {
+    css: styles
+  }, props.foo);
+}"
+`;
+
 exports[`babel-preset-zapier given a target option produces the appropriate configuration for browser 1`] = `
 Object {
   "env": Object {
@@ -20,7 +38,6 @@ Object {
         Array [
           "emotion",
           Object {
-            "autoLabel": true,
             "labelFormat": "[filename]--[local]",
             "sourceMap": true,
           },
@@ -227,7 +244,6 @@ Object {
         Array [
           "emotion",
           Object {
-            "autoLabel": true,
             "labelFormat": "[filename]--[local]",
             "sourceMap": true,
           },

--- a/index.js
+++ b/index.js
@@ -75,7 +75,6 @@ const configureEnv = (env, target) => ({
       target === 'browser' && [
         'emotion',
         {
-          autoLabel: true,
           labelFormat: '[filename]--[local]',
           sourceMap: true,
         },


### PR DESCRIPTION
The `css` function has a default functionality of formatting your css classNames as such:

`css-${hash}-{__filename}--{variableName}`

Since we have `autoLabel` set as true, this does not happen (even with `labelFormat` set!)

See the difference:

### Before
![](https://zappy.zapier.com/200c63ae40eaf383d171b8049d062361.png)

### After
![](https://zappy.zapier.com/c9d3f1118d49ae7e674228e49d0874aa.png)

### Composing styles is easy!

If you use the `css={[styles.root, styles.rootSmall]}` syntax, it will still produce developer friendly css classNames:
![](https://zappy.zapier.com/45e851f062211e0517867915f48d19ba.png)

Note: This PR makes no changes to production CSS classes