### PR TITLE
Bump version to 5.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zapier/babel-preset-zapier",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "A babel preset for Zapier",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This version has `autoLabel: true` removed so we can get the default `@emotion/core` functionality of label generation when we are not in development mode.