### PR TITLE
Release: 5.8.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ const configurePlugins = (env, target) =>
     ]
   ]);
 
-const configureEnv = (env, target) => ({
+const configureEnv = () => ({
   test: {
     plugins: ['dynamic-import-node'],
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zapier/babel-preset-zapier",
-  "version": "5.6.0",
+  "version": "5.8.0",
   "description": "A babel preset for Zapier",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Bump version 5.6.0 -> 5.8.0 - 5.7.0 was already published and not reflected on master https://zapier.slack.com/archives/C0466L7SX/p1586875292420900?thread_ts=1586872162.420500&cid=C0466L7SX

Also fixes failing ESLint errors that made it to master