### PR TITLE
Bump version to 5.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zapier/babel-preset-zapier",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "description": "A babel preset for Zapier",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
## Description

In this release, we've updated our `@babel/preset-env` to the latest version to support TypeScript 3.8, among other things.

We're going from `@babel/preset-env@7.8.3` to `7.9.5`, which includes many changes. You can read about the changes [here](https://github.com/babel/babel/blob/master/CHANGELOG.md)